### PR TITLE
test(bruno): add api endpoint tests

### DIFF
--- a/tests/bruno/tasks/create-task.bru
+++ b/tests/bruno/tasks/create-task.bru
@@ -1,0 +1,11 @@
+meta {
+  name: create-task
+  type: http
+  seq: 1
+}
+
+post {
+  url: http://localhost:3000/tasks
+  body: none
+  auth: inherit
+}

--- a/tests/bruno/tasks/delete-task.bru
+++ b/tests/bruno/tasks/delete-task.bru
@@ -1,0 +1,11 @@
+meta {
+  name: delete-task
+  type: http
+  seq: 1
+}
+
+delete {
+  url: http://localhost:3000/tasks/3
+  body: none
+  auth: inherit
+}

--- a/tests/bruno/tasks/folder.bru
+++ b/tests/bruno/tasks/folder.bru
@@ -1,0 +1,8 @@
+meta {
+  name: tasks
+  seq: 1
+}
+
+auth {
+  mode: inherit
+}

--- a/tests/bruno/tasks/get-single-task.bru
+++ b/tests/bruno/tasks/get-single-task.bru
@@ -1,0 +1,11 @@
+meta {
+  name: get-single-task
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:3000/tasks/3
+  body: none
+  auth: inherit
+}

--- a/tests/bruno/tasks/get-tasks.bru
+++ b/tests/bruno/tasks/get-tasks.bru
@@ -1,0 +1,11 @@
+meta {
+  name: get-tasks
+  type: http
+  seq: 1
+}
+
+get {
+  url: http://localhost:3000/tasks
+  body: none
+  auth: inherit
+}

--- a/tests/bruno/tasks/update-task.bru
+++ b/tests/bruno/tasks/update-task.bru
@@ -1,0 +1,17 @@
+meta {
+  name: update-task
+  type: http
+  seq: 1
+}
+
+put {
+  url: http://localhost:3000/tasks/2
+  body: json
+  auth: inherit
+}
+
+body:json {
+  {
+    "completed": true
+  }
+}


### PR DESCRIPTION
Add endpoint tests for CRUD operations. Successfully able to:

- Create new tasks
- Read all tasks
- Read a single task
- Update a task
- Delete a task